### PR TITLE
6 introduce custom fonts

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": [["styled-components", { "ssr": true, "preprocess": false }]]
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@testing-library/react": "^12.1.4",
+    "babel-plugin-styled-components": "^2.0.6",
     "next": "12.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,22 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter&display=optional"
+          rel="stylesheet"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Nunito&display=optional"
+          rel="stylesheet"
+        />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,13 @@
 import Head from 'next/head'
-import Image from 'next/image'
 import Link from 'next/link'
+import styled from 'styled-components'
+
 import styles from '../styles/Home.module.css'
+
+const Header = styled.h1`
+  color: blue;
+  font-family: Nunito;
+`
 
 export default function Home() {
   return (
@@ -13,7 +19,7 @@ export default function Home() {
       </Head>
 
       <main className={styles.main}>
-        <h1 className={styles.title}>Welcome to Dessert Wonderland</h1>
+        <Header>Welcome to Dessert Wonderland</Header>
 
         <Link href="/example/next-example">To Next example page</Link>
       </main>

--- a/yarn.lock
+++ b/yarn.lock
@@ -494,7 +494,7 @@ axobject-query@^2.2.0:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
-"babel-plugin-styled-components@>= 1.12.0":
+"babel-plugin-styled-components@>= 1.12.0", babel-plugin-styled-components@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.6.tgz#6f76c7f7224b7af7edc24a4910351948c691fc90"
   integrity sha512-Sk+7o/oa2HfHv3Eh8sxoz75/fFvEdHsXV4grdeHufX0nauCmymlnN0rGhIvfpMQSJMvGutJ85gvCGea4iqmDpg==


### PR DESCRIPTION
- Configures and integrates `styled-components` with SSR
- Creates a custom Document to add new fonts to the site `Head` ([Next docs reference](https://nextjs.org/docs/advanced-features/custom-document))
- Adds custom fonts to the `Head` [(Next docs on font optimization)](https://nextjs.org/docs/basic-features/font-optimization)
- Adds a POC using these new fonts with `styled-components`